### PR TITLE
Use gleam_erlang 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Simple PubSub for gleam
 
 Simple PubSub for gleam, based on
-[process groups](https://hex.pm/packages/process_groups).
+[process groups](https://hex.pm/packages/processgroups).
 
 [![Package Version](https://img.shields.io/hexpm/v/simple_pubsub)](https://hex.pm/packages/simple_pubsub)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/simple_pubsub/)
 
 ## Usage
 
-Add this  library to your Gleam project
+Add this library to your Gleam project
 
 ```sh
 gleam add simple_pubsub
@@ -20,7 +20,7 @@ And use it in your project
 
 ```gleam
 import simple_pubsub as ps
-import process_groups
+import processgroups
 import gleam/erlang/process
 
 // Messages we want to send over the PubSub
@@ -30,7 +30,7 @@ type PubSubMessage{
 
 pub fn main() {
     // start process groups, needed for pubsub
-    process_groups.start_link()
+    processgroups.start_link()
 
     // create a pubsub
     let pubsub = ps.new_pubsub()
@@ -45,6 +45,7 @@ pub fn main() {
     let assert Ok(PubSubMessage) = ps.receive(subscription, 100)
 }
 ```
+
 ## Development
 
 ```sh

--- a/gleam.toml
+++ b/gleam.toml
@@ -9,10 +9,9 @@ links = [{ title = "gleam", href = "https://gleam.run" }]
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-gleam_erlang = ">= 0.25.0 and < 1.0.0"
-processgroups = ">= 0.1.3 and < 1.0.0"
+gleam_stdlib = ">= 0.60.0 and < 2.0.0"
+gleam_erlang = ">= 1.2.0 and < 2.0.0"
+processgroups = { git = "git@github.com:Nicd/gleam_processgroups.git", ref = "gleam-erlang-1.0.0" }
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
-gleam_otp = ">= 0.10.0 and < 1.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,16 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
-  { name = "gleam_stdlib", version = "0.58.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "091F2D2C4A3A4E2047986C47E2C2C9D728A4E068ABB31FDA17B0D347E6248467" },
-  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
-  { name = "processgroups", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "processgroups", source = "hex", outer_checksum = "A2F2CD361C23865440AF8ACE95D3C1BE4181A0F7B974D0C77C81A7D53F32C4E3" },
+  { name = "gleam_erlang", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "F91CE62A2D011FA13341F3723DB7DB118541AAA5FE7311BD2716D018F01EF9E3" },
+  { name = "gleam_stdlib", version = "0.61.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3DC407D6EDA98FCE089150C11F3AD892B6F4C3CA77C87A97BAE8D5AB5E41F331" },
+  { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
+  { name = "processgroups", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], source = "git", repo = "git@github.com:Nicd/gleam_processgroups.git", commit = "3c9e49236467ffe23a2010914d547df5d0095e41" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
-gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.60.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-processgroups = { version = ">= 0.1.3 and < 1.0.0" }
+processgroups = { git = "git@github.com:Nicd/gleam_processgroups.git", ref = "gleam-erlang-1.0.0" }

--- a/src/simple_pubsub.gleam
+++ b/src/simple_pubsub.gleam
@@ -1,6 +1,7 @@
 import gleam/dynamic
-import gleam/erlang
+import gleam/dynamic/decode
 import gleam/erlang/process
+import gleam/erlang/reference.{type Reference}
 import gleam/list
 import processgroups as pg
 
@@ -9,7 +10,7 @@ fn unsafe_coerce(a: dynamic.Dynamic) -> a
 
 /// A pubsub, where process can subscribe and anyone can broadcast
 pub type PubSub(message) {
-  PubSub(tag: erlang.Reference)
+  PubSub(tag: Reference)
 }
 
 /// A Subscription is crated by subscribing to a PubSub
@@ -21,7 +22,7 @@ pub type Subscription(message) {
 
 /// Create a new pubsub
 pub fn new_pubsub() -> PubSub(message) {
-  PubSub(erlang.make_reference())
+  PubSub(reference.new())
 }
 
 /// Subscribe a process to a PubSub.
@@ -42,7 +43,7 @@ pub fn receive(
 ) -> Result(message, Nil) {
   process.new_selector()
   |> selecting_pubsub_subject(subject, fn(x) { x })
-  |> process.select(within: milliseconds)
+  |> process.selector_receive(within: milliseconds)
 }
 
 /// Unsubsribe a process from a PubSub.
@@ -68,18 +69,18 @@ pub fn selecting_pubsub_subject(
   subject: Subscription(message),
   handler: fn(message) -> payload,
 ) -> process.Selector(payload) {
-  process.selecting_record2(selector, subject.pubsub.tag, fn(d) {
-    d
-    |> unsafe_coerce
-    |> handler
+  process.select_record(selector, subject.pubsub.tag, 1, fn(d) {
+    let assert Ok(payload) =
+      decode.run(d, decode.field(1, decode.dynamic, decode.success))
+    handler(unsafe_coerce(payload))
   })
 }
 
-/// Monitor a PubSub. A `pg.GorupMonitor` event will be 
-/// send, when a process subscribes or unsubscribes.
+/// Monitor a PubSub. A `pg.GroupMonitor` event will be
+/// sent when a process subscribes or unsubscribes.
 pub fn monitor(
   pubsub: PubSub(message),
-) -> #(pg.GroupMonitor(erlang.Reference), List(process.Pid)) {
+) -> #(pg.GroupMonitor(Reference), List(process.Pid)) {
   pg.monitor(pubsub.tag)
 }
 

--- a/test/simple_pubsub_test.gleam
+++ b/test/simple_pubsub_test.gleam
@@ -1,6 +1,5 @@
 import gleam/erlang/process
 import gleam/list
-import gleam/otp/task
 import gleeunit
 import gleeunit/should
 import processgroups as pg
@@ -32,15 +31,17 @@ pub fn send_receive_multiple_test() {
   // setup
   let pubsub = ps.new_pubsub()
   let #(monitor, _) = ps.monitor(pubsub)
-  let tasks =
+  let task_subjects =
     list.range(1, 10)
     |> list.map(fn(_) {
+      let parent = process.new_subject()
       // start the task
-      let task =
-        task.async(fn() {
+      process.spawn(fn() {
+        let assert Ok(msg) =
           ps.subscribe(pubsub, process.self())
           |> ps.receive(100)
-        })
+        process.send(parent, msg)
+      })
       // wait for it to register
       let _ =
         pg.selecting_process_group_monitor(
@@ -48,17 +49,17 @@ pub fn send_receive_multiple_test() {
           monitor,
           fn(a) { a.pids },
         )
-        |> process.select(100)
-      // return the task
-      task
+        |> process.selector_receive(100)
+      // return the task subject to receive on
+      parent
     })
 
   // act
   ps.broadcast(pubsub, PubSubMessage)
   let res =
-    tasks
+    task_subjects
     |> list.map(fn(t) {
-      let assert Ok(msg) = task.await(t, 100)
+      let assert Ok(msg) = process.receive(t, 100)
       msg
     })
 


### PR DESCRIPTION
The `gleam_erlang` dependency was bumped to 1.2.0. Tests pass, but you may want to carefully review the changes. It's also depending on the unpublished PR version of `processgroups`, so you'll want to switch that dependency out when `processgroups` is updated.